### PR TITLE
Properly map redis nil response to http 404

### DIFF
--- a/src/services/otps.rs
+++ b/src/services/otps.rs
@@ -139,26 +139,32 @@ pub async fn authorize(
 /// ```
 fn handle_redis_error(e: RedisError) -> ServiceError {
     let detail = e.detail().unwrap_or("Unknown error").to_owned();
-    let status = match e.kind() {
-        ErrorKind::ResponseError => StatusCode::INTERNAL_SERVER_ERROR,
-        ErrorKind::AuthenticationFailed => StatusCode::UNAUTHORIZED,
-        ErrorKind::TypeError => StatusCode::BAD_REQUEST,
-        ErrorKind::ExecAbortError => StatusCode::INTERNAL_SERVER_ERROR,
-        ErrorKind::BusyLoadingError => StatusCode::SERVICE_UNAVAILABLE,
-        ErrorKind::NoScriptError => StatusCode::INTERNAL_SERVER_ERROR,
-        ErrorKind::InvalidClientConfig => StatusCode::BAD_REQUEST,
-        ErrorKind::Moved => StatusCode::MOVED_PERMANENTLY,
-        ErrorKind::Ask => StatusCode::TEMPORARY_REDIRECT,
-        ErrorKind::TryAgain => StatusCode::INTERNAL_SERVER_ERROR,
-        ErrorKind::ClusterDown => StatusCode::SERVICE_UNAVAILABLE,
-        ErrorKind::CrossSlot => StatusCode::INTERNAL_SERVER_ERROR,
-        ErrorKind::MasterDown => StatusCode::SERVICE_UNAVAILABLE,
-        ErrorKind::IoError => StatusCode::INTERNAL_SERVER_ERROR,
-        ErrorKind::ClientError => StatusCode::BAD_REQUEST,
-        ErrorKind::ExtensionError => StatusCode::INTERNAL_SERVER_ERROR,
-        ErrorKind::ReadOnly => StatusCode::FORBIDDEN,
-        // ErrorKind::Serialize => StatusCode::INTERNAL_SERVER_ERROR,
-        _ => StatusCode::INTERNAL_SERVER_ERROR,
+    let status = if detail.contains("Response type not string compatible")
+        || detail.contains("response was nil")
+    {
+        StatusCode::NOT_FOUND
+    } else {
+        match e.kind() {
+            ErrorKind::ResponseError => StatusCode::INTERNAL_SERVER_ERROR,
+            ErrorKind::AuthenticationFailed => StatusCode::UNAUTHORIZED,
+            ErrorKind::TypeError => StatusCode::BAD_REQUEST,
+            ErrorKind::ExecAbortError => StatusCode::INTERNAL_SERVER_ERROR,
+            ErrorKind::BusyLoadingError => StatusCode::SERVICE_UNAVAILABLE,
+            ErrorKind::NoScriptError => StatusCode::INTERNAL_SERVER_ERROR,
+            ErrorKind::InvalidClientConfig => StatusCode::BAD_REQUEST,
+            ErrorKind::Moved => StatusCode::MOVED_PERMANENTLY,
+            ErrorKind::Ask => StatusCode::TEMPORARY_REDIRECT,
+            ErrorKind::TryAgain => StatusCode::INTERNAL_SERVER_ERROR,
+            ErrorKind::ClusterDown => StatusCode::SERVICE_UNAVAILABLE,
+            ErrorKind::CrossSlot => StatusCode::INTERNAL_SERVER_ERROR,
+            ErrorKind::MasterDown => StatusCode::SERVICE_UNAVAILABLE,
+            ErrorKind::IoError => StatusCode::INTERNAL_SERVER_ERROR,
+            ErrorKind::ClientError => StatusCode::BAD_REQUEST,
+            ErrorKind::ExtensionError => StatusCode::INTERNAL_SERVER_ERROR,
+            ErrorKind::ReadOnly => StatusCode::FORBIDDEN,
+            // ErrorKind::Serialize => StatusCode::INTERNAL_SERVER_ERROR,
+            _ => StatusCode::INTERNAL_SERVER_ERROR,
+        }
     };
 
     ServiceError { detail, status }


### PR DESCRIPTION
The server returns a 500 when the OTP param does not exist in the Redis DB. This PR resolves the issue by checking if the error message matches specific strings. The Redis crate does not have a more detailed error type and the raw code does not exist, hence the solution.